### PR TITLE
Pre release

### DIFF
--- a/software/config/defaults.yml
+++ b/software/config/defaults.yml
@@ -109,7 +109,7 @@ Top:
         totf: 0x0
         tot_overflow: 0x0
         toa_busy: 0x0
-        toa_ready: 0x0
+        Hit: 0x0
         tot_busy: 0x0
         tot_ready: 0x0
         en_read: 0x0

--- a/software/config/defaults.yml
+++ b/software/config/defaults.yml
@@ -42,7 +42,7 @@ Top:
       totf_satovfw: 0x0
       totc_satovfw: 0x0
       toa_satovfw: 0x0
-      ckw_choice: 0x0
+      Ck40_choice: 0x0
       cBitf: 0x0
       DLL_ALockR_en: 0x1
       CP_b: 0x3
@@ -72,7 +72,9 @@ Top:
       cd[4]: 0x0
       PLL: 0x1
       dac_icpb: 0xa
-      dac_CP_BWb: 0x20
+      # dac_CP_BWb: 0x20 # Legacy V1 value
+      Shifted_ck40: 0x0
+      dac_CP_BWb: 0x10 # V2 maps dac_CP_BW<0> to Shifted_ck40
       EN_Ext_Vin_VCO: 0x0
       setN: 0x3
       setProbe: 0x0

--- a/software/config/test.yml
+++ b/software/config/test.yml
@@ -109,7 +109,7 @@ Top:
         totf: 0x0
         tot_overflow: 0x0
         toa_busy: 0x0
-        toa_ready: 0x0
+        Hit: 0x0
         tot_busy: 0x0
         tot_ready: 0x0
         en_read: 0x0

--- a/software/config/test.yml
+++ b/software/config/test.yml
@@ -42,7 +42,7 @@ Top:
       totf_satovfw: 0x0
       totc_satovfw: 0x0
       toa_satovfw: 0x0
-      ckw_choice: 0x0
+      Ck40_choice: 0x0
       cBitf: 0x0
       DLL_ALockR_en: 0x1
       CP_b: 0x3
@@ -72,7 +72,9 @@ Top:
       cd[4]: 0x0
       PLL: 0x1
       dac_icpb: 0xa
-      dac_CP_BWb: 0x20
+      # dac_CP_BWb: 0x20 # Legacy V1 value
+      Shifted_ck40: 0x0
+      dac_CP_BWb: 0x10 # V2 maps dac_CP_BW<0> to Shifted_ck40
       EN_Ext_Vin_VCO: 0x0
       setN: 0x3
       setProbe: 0x0

--- a/software/python/common/_AltirocProbe.py
+++ b/software/python/common/_AltirocProbe.py
@@ -185,8 +185,8 @@ class AltirocProbe(pr.Device):
             )   
 
             addPixReg(
-                name        = 'toa_ready',
-                description = 'digital_probe2',
+                name        = 'Hit',
+                description = 'digital_probe2 (was toa_ready in Legacy V1)',
                 bitSize     = 1, 
                 bitOffset   = (41+(29*i)),
                 device      = pixDev,

--- a/software/python/common/_AltirocSlowControl.py
+++ b/software/python/common/_AltirocSlowControl.py
@@ -224,11 +224,11 @@ class AltirocSlowControl(pr.Device):
         )
         
         addReg(
-            name        = 'ckw_choice', 
-            description = 'DLL',
+            name        = 'Ck40_choice', 
+            description = '40MHz choice',
             bitSize     = 1, 
             bitOffset   = 59,
-            value       = 0x0, # DEF Value
+            value       = 0x1, # DEF Value
             base        = downToBitOrdering,
         )  
         
@@ -463,12 +463,21 @@ class AltirocSlowControl(pr.Device):
             value       = 0xA, # DEF Value
             base        = upToBitOrdering,            
         ) 
-
+        
+        addReg(
+            name        = 'Shifted_ck40', 
+            description = 'Was dac_CP_BW<0> in V1',
+            bitSize     = 1, 
+            bitOffset   = 927,
+            value       = 0x0, # DEF Value
+            base        = downToBitOrdering,            
+        ) 
+        
         addReg(
             name        = 'dac_CP_BWb', 
             description = '',
-            bitSize     = 6, 
-            bitOffset   = 927,
+            bitSize     = 5, 
+            bitOffset   = 928,
             value       = 0x20, # DEF Value
             base        = upToBitOrdering,            
         )

--- a/software/scripts/test_Bojan.py
+++ b/software/scripts/test_Bojan.py
@@ -238,7 +238,7 @@ if Disable_CustomConfig == 0:                                  ##
         top.Asic.Probe.pix[i].totf.set(0x0)                    ##
         top.Asic.Probe.pix[i].tot_overflow.set(0x0)            ##
         top.Asic.Probe.pix[i].toa_busy.set(0x0)                ##
-        top.Asic.Probe.pix[i].toa_ready.set(0x0)               ##
+        top.Asic.Probe.pix[i].Hit.set(0x0)                     ##
         top.Asic.Probe.pix[i].tot_busy.set(0x0)                ##
         top.Asic.Probe.pix[i].tot_ready.set(0x0)               ##
         top.Asic.Probe.pix[i].en_read.set(0x0)                 ##
@@ -271,7 +271,7 @@ if Disable_CustomConfig == 0:                                  ##
     top.Asic.Probe.pix[pixel_number].totf.set(0x0)             ##
     top.Asic.Probe.pix[pixel_number].tot_overflow.set(0x0)     ##
     top.Asic.Probe.pix[pixel_number].toa_busy.set(0x1)         ##
-    top.Asic.Probe.pix[pixel_number].toa_ready.set(0x0)        ##
+    top.Asic.Probe.pix[pixel_number].Hit.set(0x0)              ##
     top.Asic.Probe.pix[pixel_number].tot_busy.set(0x0)         ##
     top.Asic.Probe.pix[pixel_number].tot_ready.set(0x0)        ##
     top.Asic.Probe.pix[pixel_number].en_read.set(0x1)          ##


### PR DESCRIPTION
[datasheet_Altiroc1_V2_5April2019.pdf](https://github.com/slaclab/atlas-altiroc-daq/files/3098648/datasheet_Altiroc1_V2_5April2019.pdf)

### Description
- Table 3, SC parameters (page 13):  
  - SC parameter @ addr 59 : ckw_choice (in Altiroc1_V1) renamed as ck40_choice (in V2)
  - SC parameter @ addr 927:  dac_CP_BWb<0> (in V1) renamed Shifted_ck40 (in V2)
- Table 4, probe register (page 24): 
  - probe@addr 41, 99, 128 .... 708  was "toa_ready" in Altiroc1_V1 and is now "Hit"
